### PR TITLE
Version 0.2.11

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Eegle"
 uuid = "1260424e-cd79-4b74-a0ea-47c69c296663"
-version = "0.2.10"
+version = "0.2.11"
 authors = ["Marco Congedo, Fahim Doumi"]
 
 [deps]

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 | EEG BCI Data | Package's Clones | Unicode Symbol | Official Logo |  
 |:-----:|:-----:|:-----:|:-----:|
-| [![](https://img.shields.io/badge/Motor_Imagery-blue.svg)](https://zenodo.org/records/17801878) [![](https://img.shields.io/badge/P300-blue.svg)](https://zenodo.org/records/18379398) | [![](https://img.shields.io/badge/pyLittleEegle-blue.svg)](https://github.com/FhmDmi/pyLittleEegle) | 🦅 `\:eagle:`| <img src="docs/src/assets/logo_verysmall.png" height="48"> |  
+| [![](https://img.shields.io/badge/Motor_Imagery-blue.svg)](https://zenodo.org/records/17801878) [![](https://img.shields.io/badge/P300-blue.svg)](https://zenodo.org/records/21687278) | [![](https://img.shields.io/badge/pyLittleEegle-blue.svg)](https://github.com/FhmDmi/pyLittleEegle) | 🦅 `\:eagle:`| <img src="docs/src/assets/logo_verysmall.png" height="48"> |  
 
 
 # Eegle (EEG general library) 

--- a/docs/src/Database.md
+++ b/docs/src/Database.md
@@ -25,7 +25,8 @@ Most functionalities of this module are also encapsulated in the [pyLittleEegle]
 |[`Eegle.Database.infoDB`](@ref)        | print, save and return metadata about a database |
 |[`Eegle.Database.selectDB`](@ref)      | select databases and sessions based on inclusion criteria
 |[`Eegle.Database.weightsDB`](@ref)     | get weights for each session of a database for statistical analysis |
-|[`Eegle.Database.downloadDB`](@ref)    | run a web-based GUI to dowload the FII BCI corpus. |
+|[`Eegle.Database.downloadDB`](@ref)    | run a web-based GUI to download the FII BCI corpus |
+|[`Eegle.Database.corpusDir`](@ref)     | return the directory where the FII BCI corpus has been downloaded |
 
 📖
 ```@docs
@@ -35,4 +36,5 @@ Most functionalities of this module are also encapsulated in the [pyLittleEegle]
     Eegle.Database.selectDB
     Eegle.Database.weightsDB
     Eegle.Database.downloadDB
+    Eegle.Database.corpusDir
 ```

--- a/docs/src/documents/Benchmark.md
+++ b/docs/src/documents/Benchmark.md
@@ -2,7 +2,7 @@
 
 This document reports the results of a benchmark run on the [FII BCI Corpus](@ref "FII BCI Corpus Overview") using **Eegle**.
 
-Only subjects/sessions that passed *all exclusion criteria* described in the *@discarded.md* file (see it for [MI](https://zenodo.org/records/17801878/files/@discarded.md?download=1) and [P300](https://zenodo.org/records/17793672/files/@discarded.md?download=1)) were included in this benchmark.
+Only subjects/sessions that passed *all exclusion criteria* described in the *@discarded.md* file (see it for [MI](https://zenodo.org/records/21687278/files/@discarded.md?download=1) and [P300](https://zenodo.org/records/21688242/files/@discarded.md?download=1)) were included in this benchmark.
 
 Individual subject/session accuracies are included in the `.yml` [metadata files](@ref "NY Metadata (YAML)") and are also available in CSV format in this [GitHub repository](https://github.com/FhmDmi/Eegle-Tools/tree/master/Within-Session-Evaluation/results). The repository also hosts the scripts used to make this benchmark and more information. 
 

--- a/docs/src/documents/FII BCI Corpus Overview.md
+++ b/docs/src/documents/FII BCI Corpus Overview.md
@@ -34,7 +34,7 @@ The data curation included:
 - cleaning of NaN and zero values at the beginning and ending of the recordings,
 - conversion of the cleaned data from CSV to the [NY format](@ref), easily accessible in any programming language.
 
-For the details on the discarding procedures for each file see the *@discarded.md* file for [MI](https://zenodo.org/records/17801878/files/@discarded.md?download=1) and [P300](https://zenodo.org/records/17793672/files/@discarded.md?download=1).
+For the details on the discarding procedures for each file see the *@discarded.md* file for [MI](https://zenodo.org/records/21687278/files/@discarded.md?download=1) and [P300](https://zenodo.org/records/21688242/files/@discarded.md?download=1).
 
 For the details on the treatment that has been carried out on each database, see [Treatment MI](@ref) and [Treatment P300](@ref).
 

--- a/src/Database.jl
+++ b/src/Database.jl
@@ -23,8 +23,8 @@ export
     infoDB,
     selectDB,
     weightsDB,
-    downloadDB
-
+    downloadDB,
+    corpusDir # from GUIs\downloadDB\db_catalog.jl
 
 """
 ```julia
@@ -658,7 +658,7 @@ end
 
 """
 ```julia
-function selectDB([corpusDir    :: String,] 
+function selectDB([corpusdir    :: String,] # may be omitted
                   paradigm      :: Symbol;
                   classes       :: Union{Vector{String}, Nothing} = paradigm == :P300 ? ["target", "nontarget"] : nothing,
                   inclusion     :: Union{Tuple, Nothing} = nothing,
@@ -672,11 +672,11 @@ Return the selected databases as a list of [`InfoDB`](@ref) structures,
 wherein the `InfoDB.files` field lists the included sessions only.
 
 **Arguments**
-- `corpusDir`: the directory on the local computer where to start the search. Any folder in this directory is a candidate [database](@ref) to be selected.
+- `corpusdir`: the directory on the local computer where to start the search. Any folder in this directory is a candidate [database](@ref) to be selected.
 
 !!! tip "Smart Search"
-    If a folder with the same name of the paradigm (for example: "MI") is found in `corpusDir`, the search starts therein
-    and not in `corpusDir`. This way you can use the same `corpusDir` for all paradigms.
+    If a folder with the same name of the paradigm (for example: "MI") is found in `corpusdir`, the search starts therein
+    and not in `corpusdir`. This way you can use the same `corpusdir` for all paradigms.
 
     If you want to use the [FII BCI corpus](@ref "FII BCI Corpus Overview") and you have downloaded it using the provided GUI — see [`downloadDB`](@ref) —, you can simply
     omit this argument; **Eegle** will automatically search within the FII BCI Corpus directory.
@@ -785,7 +785,7 @@ DB_P300 = selectDB(:P300;
 [`infoDB`](@ref), [`loadDB`](@ref), [`weightsDB`](@ref)
 
 """
-function selectDB(corpusDir     :: String,
+function selectDB(corpusdir     :: String,
                   paradigm      :: Symbol;
                   classes       :: Union{Vector{String}, Nothing} = paradigm == :P300 ? ["target", "nontarget"] : nothing,
                   inclusion     :: Union{Tuple, Nothing} = nothing,
@@ -800,12 +800,12 @@ function selectDB(corpusDir     :: String,
     end
 
     # Check if there's a paradigm subfolder and move to it if it exists
-    paradigmDir = joinpath(corpusDir, string(paradigm))
-    isdir(paradigmDir) && (corpusDir = paradigmDir)
-    !isdir(corpusDir) && error("Eegle.Database, function `selectDB`: the provided directory `corpusDir` is not valid. Please check: $corpusDir") 
+    paradigmDir = joinpath(corpusdir, string(paradigm))
+    isdir(paradigmDir) && (corpusdir = paradigmDir)
+    !isdir(corpusdir) && error("Eegle.Database, function `selectDB`: the provided directory `corpusdir` is not valid. Please check: $corpusdir") 
 
-    dbDirs = getFoldersInDir(corpusDir)
-    isempty(dbDirs) && error("Eegle.Database, function `selectDB`: No database found in the directory: $corpusDir")
+    dbDirs = getFoldersInDir(corpusdir)
+    isempty(dbDirs) && error("Eegle.Database, function `selectDB`: No database found in the directory: $corpusdir")
 
     # Check paradigm and classes requirements - no error for MI/ERP without classes
     if (paradigm == :MI || paradigm == :ERP) && isnothing(classes)
@@ -969,11 +969,11 @@ function selectDB(paradigm      :: Symbol;
                   summarize     :: Bool = true,
                   verbose       :: Bool = false)
 
-    corpusDir = _dirFII() # see GUIs\downloadDB\db_catalog.jl
-    if isnothing(corpusDir)
-        throw(ArgumentError("Eegle.Database.selectDB: the default directory of the FII BCI Corpus has not been found. Please install the corpus running `downloadDB()`. Looking into $corpusDir"))
+    corpusdir = corpusDir() # see GUIs\downloadDB\db_catalog.jl
+    if isnothing(corpusdir)
+        throw(ArgumentError("Eegle.Database.selectDB: the default directory of the FII BCI Corpus has not been found. Please install the corpus running `downloadDB()`"))
     else
-        selectDB(corpusDir, paradigm; classes, inclusion, summarize, verbose)
+        selectDB(corpusdir, paradigm; classes, inclusion, summarize, verbose)
     end
 end
 
@@ -1172,7 +1172,7 @@ function downloadDB(urls::Vector{String}, dest::String = homedir())
 
 Open an interactive GUI to select and download databases from the FII BCI Corpus.
 
-!!! warning "Make sure you have enough space of disk"
+!!! warning "Make sure you have enough space on disk"
     The size of the corpus on disk is **36.6 GB** for MI and **14.2 GB** for P300.
     
 The GUI will open in the primary HTML display found in the Julia display stack, which typically
@@ -1203,8 +1203,8 @@ is printed when the download has ended.
     The databases pertaining to the MI and P300 paradigm must be downloaded separately.
 
 !!! tip "Using the FII BCI Corpus"
-    Once the corpus is downloaded, **Eegle** knows automatically where to find it. Therefore, omitting the argument `corpusDir` while using function [`Eegle.Database.selectDB`](@ref)
-    will automatically point to the FII BCI corpus. 
+    Once the corpus is downloaded, **Eegle** knows automatically where to find it. Therefore, omitting the argument `corpusdir` while using function [`Eegle.Database.selectDB`](@ref)
+    will automatically point to the FII BCI corpus. However, if you install a new Julia or Eegle version, you have to call this function again.
 
 (2) **Direct download of a single [Zenodo](https://zenodo.org/) record**
 

--- a/src/GUIs/downloadDB/db_catalog.jl
+++ b/src/GUIs/downloadDB/db_catalog.jl
@@ -305,8 +305,26 @@ function write_in_Eegle_package(download_path, overwrite)
     end
 end
 
-# Returns the stored corpus path from Eegle’s internal configuration file.
-function _dirFII() 
+"""
+```julia
+function corpusDir()
+```
+
+If the [FII BCI corpus](@ref "FII BCI Corpus Overview") has been downloaded using [`downloadDB`](@ref),
+return the directory where it has been stored.
+
+**Example**
+```julia
+using Eegle # or using Eegle.Database
+
+# get the full path of all .npz (data) files of database AlexMI
+db = getFilesInDir(joinpath(corpusDir(), "MI", "AlexMI"); ext=(".npz", ))
+
+# process the data file by file ...
+
+```
+"""
+function corpusDir() 
     file = FII_BCI_CORPUS_PATHFILE
     isfile(file) || (return nothing)
     path = normpath(readlines(FII_BCI_CORPUS_PATHFILE)[1])


### PR DESCRIPTION
Added function `corpusDir()`,
which returns the directory where the FII BCI corpus has been installed using `downloadDB()`